### PR TITLE
fix: handle unhandled error from s.manifestWriter.Close() in leveldb/session_util.go

### DIFF
--- a/leveldb/session_util.go
+++ b/leveldb/session_util.go
@@ -426,7 +426,9 @@ func (s *session) newManifest(rec *sessionRecord, v *version) (err error) {
 				s.manifest.Close()
 			}
 			if s.manifestWriter != nil {
-				s.manifestWriter.Close()
+				if err := s.manifestWriter.Close(); err != nil {
+					s.logf("error closing manifest writer: %v", err)
+				}
 			}
 			if !s.manifestFd.Zero() {
 				err = s.stor.Remove(s.manifestFd)


### PR DESCRIPTION
### Summary

The unhandled error in `session_util.go` has been fixed. The error returned by `s.manifestWriter.Close()` is now handled to prevent unnoticed failures in closing the manifest writer, which could potentially cause data corruption or loss.

### Changes Made
- **File**: `leveldb/session_util.go`
- **Line**: 429
- **Function**: `newManifest`
- **Change**: Added error handling for `s.manifestWriter.Close()`.

### Commit Details
- **Branch**: `fix-unhandled-error-session-util`
- **Commit Message**: 
  ```
  fix: handle unhandled error from s.manifestWriter.Close() in leveldb/session_util.go

  Ensured that the error returned by s.manifestWriter.Close() is handled to prevent unnoticed failures in closing the manifest writer, which could potentially cause data corruption or loss.
  ```

### Next Steps
- A pull request can be created for the branch `fix-unhandled-error-session-util` to merge the changes into the main branch.

You can view and create the pull request [here](https://github.com/org404/goleveldb/pull/new/fix-unhandled-error-session-util).