### PR TITLE
Fix Directory Permission Issue

### DIFF
--- a/leveldb/storage/file_storage.go
+++ b/leveldb/storage/file_storage.go
@@ -97,7 +97,7 @@ func OpenFile(path string, readOnly bool) (Storage, error) {
 			return nil, fmt.Errorf("leveldb/storage: open %s: not a directory", path)
 		}
 	} else if os.IsNotExist(err) && !readOnly {
-		if err := os.MkdirAll(path, 0755); err != nil {
+		if err := os.MkdirAll(path, 0750); err != nil {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
## Summary

This pull request addresses a directory permission issue in the `goleveldb` repository. The permission for the `os.MkdirAll` function call has been changed from `0755` to `0750` to mitigate a potential security vulnerability.

## Details

- **File**: `leveldb/storage/file_storage.go`
- **Line**: 100
- **Change**: Modified the permission in the `os.MkdirAll` call from `0755` to `0750`.

## Impact

This change restricts directory access to the owner and group, reducing the risk of unauthorized access.

## Next Steps

1. **Code Review**: Review the changes to ensure they meet the security requirements.
2. **Testing**: Run tests to verify that the changes do not introduce any regressions or new issues.
3. **Merge**: Merge the pull request after successful review and testing.

## References

- [GitHub Security Lab Advisory](https://securitylab.github.com/advisories/GHSL-2020-257-zipslip-oras/)

Thank you for your attention to this matter.