### PR TITLE
fix: update golang.org/x/net to v0.7.0 to address CVE-2022-41723

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220607020251-c690dde0001d h1:4SFsTMi4UahlKoloni7L4eYzhFRifURQLw+yv0QDCx8=
-golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.7.0 h1:4SFsTMi4UahlKoloni7L4eYzhFRifURQLw+yv0QDCx8=
+golang.org/x/net v0.7.0/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
### Summary

This pull request addresses the high-severity vulnerability CVE-2022-41723 in the `golang.org/x/net` package. The vulnerability could be exploited via a specially crafted HTTP/2 stream, causing excessive CPU consumption in the HPACK decoder and leading to a Denial of Service (DoS).

### Changes
- Updated the `golang.org/x/net` package to version `v0.7.0` in the `go.sum` file.

### Evidence
- **File**: `go.sum`
- **Line**: 65
- **Details**: "Possible vulnerability detected: A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests."

### References
- [CVE-2022-41723](https://avd.aquasec.com/nvd/cve-2022-41723)
- [Twingate](https://www.twingate.com/blog/tips/cve-2022-41723)
- [Snyk](https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXNETHTTP2HPACK-3358253)

### Recommendations
- It is highly recommended to merge this pull request to mitigate the vulnerability and protect against potential DoS attacks.